### PR TITLE
release candidate v0.0.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aae.pop.templates
 Type: Package
 Title: Parameterised Population Dynamics Models
-Version: 0.0.3.9004
+Version: 0.0.4
 Date: 2023-02-22
 Author: c(
   person(given = "Jian",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,36 +1,23 @@
-# aae.pop.templates (development version)
+# aae.pop.templates 0.0.4
 
-## aae.pop.templates 0.0.3.9004
+## Features
 
-### Features
+- Add template for river blackfish and set default coefficients based on
+    inference (`river_blackfish`)
+- Add template for Murray-Darling rainbowfish and set default coefficients
+    based on inference (`murray_rainbowfish`)
 
-- Update default Murray rainbowfish coefficients based on inference
 
-## aae.pop.templates 0.0.3.9003
+## API changes
 
-### Features
+- initial template name for rainbowfish (`murray_darling_rainbowfish`)
+    changed to `murray_rainbowfish`
 
-- Update default river blackfish coefficients based on inference
-
-## aae.pop.templates 0.0.3.9002
-
-### Features
-
-- Add template for river blackfish
-
-### API changes
-
-- `murray_darling_rainbowfish` template name changed to `murray_rainbowfish`
-
-## aae.pop.templates 0.0.3.9001
-
-### Features
-
-- Add template for Murray-Darling rainbowfish
 
 # aae.pop.templates 0.0.3
 
 - Add tests of covariate methods and carp and bass templates
+
 
 # aae.pop.templates 0.0.2
 


### PR DESCRIPTION
# aae.pop.templates 0.0.4

## Features

- Add template for river blackfish and set default coefficients based on
    inference (`river_blackfish`)
- Add template for Murray-Darling rainbowfish and set default coefficients
    based on inference (`murray_rainbowfish`)


## API changes

- initial template name for rainbowfish (`murray_darling_rainbowfish`)
    changed to `murray_rainbowfish`
